### PR TITLE
Allow `object` to inherit options from group

### DIFF
--- a/lib/bluepine/attributes/object_attribute.rb
+++ b/lib/bluepine/attributes/object_attribute.rb
@@ -9,8 +9,8 @@ module Bluepine
       self.stacks = []
 
       def initialize(name, options = {}, &block)
-        @name       = name
-        @options    = options
+        super
+
         @attributes = {}
         instance_exec(&block) if block_given?
       end

--- a/test/bluepine/attributes/object_attribute_test.rb
+++ b/test/bluepine/attributes/object_attribute_test.rb
@@ -69,6 +69,7 @@ class Bluepine::Attributes::ObjectAttributeTest < BaseAttribute
           end
 
           assert_equal :deleted_1, attr[:name_1].if
+          assert_equal :deleted_1, attr[:nested].if
           assert_equal :deleted_2, attr[:nested][:name_2].if
           assert_nil attr[:kitten].if
         end


### PR DESCRIPTION
Should an `object` attribute inside of a `group` inherit the options from the group?

Currently the `ObjectAttribute` overrides the initialize method but doesn't use `Attribute.options` to inherit the options from the group.

This PR calls `super` to call `@options = self.class.options.merge(options)` from `Attribute` class.